### PR TITLE
Fixed issue #8 "move dmps in a timestamped-sub-directory to avoid collis...

### DIFF
--- a/app/controllers/Dmp.scala
+++ b/app/controllers/Dmp.scala
@@ -36,11 +36,10 @@ object Dmp extends Controller {
    * @param absoluteRootPath the root folder for searching the static resource files such as `"/home/peter/public"`, `C:\external` or `relativeToYourApp`
    * @param file the file part extracted from the URL
    */
-  def at(rootPath: String, file: String): Action[AnyContent] = Action { request =>
-    val fileToServe = rootPath match {
-      case AbsolutePath(_) => new File(rootPath, file)
-      case _ => new File(Play.application.getFile(rootPath), file)
-    }
+  def at(file: String): Action[AnyContent] = Action { request =>
+    
+    val dmpPath = Play.current.configuration.getString("dmpster.dmp.path").getOrElse("C:\\dumps")
+    val fileToServe = new File(dmpPath, file)
 
     if (fileToServe.exists) {
       Ok.sendFile(fileToServe, inline = true).withHeaders(CACHE_CONTROL -> "max-age=3600")

--- a/app/views/bucket.scala.html
+++ b/app/views/bucket.scala.html
@@ -23,7 +23,7 @@
 	@dumps.map { dump =>
 		<section class="@if(dump.isNew) { new } dmp">
 			<h1>
-				<a href="@routes.Dmp.at(dump.filename)"><img src="@routes.Assets.at("images/download.svg")"></img></a>
+				<a href="@routes.Dmp.at(dump.relFilePath)"><img src="@routes.Assets.at("images/download.svg")"></img></a>
 				<a href="@routes.Application.viewDetails(dump.id)">@dump.filename</a>
 			</h1>
 			

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -5,7 +5,7 @@
 	
 	<section>
 		<h1>
-			<a href="@routes.Dmp.at(dump.filename)"><img src="@routes.Assets.at("images/download.svg")"></img></a>
+			<a href="@routes.Dmp.at(dump.relFilePath)"><img src="@routes.Assets.at("images/download.svg")"></img></a>
 			@listTags(dump)
 		</h1>
 		<pre>

--- a/conf/routes
+++ b/conf/routes
@@ -7,7 +7,7 @@ GET     /                           controllers.Application.index
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)
-GET		/dmps/*file					controllers.Dmp.at(path="C:\\dumps", file)
+GET		/dmps/*file					controllers.Dmp.at(file)
 
 GET		/dmpster							controllers.Application.dmpster
 GET		/dmpster/newerThan/:timestamp		controllers.Application.newerThan(timestamp: Long)


### PR DESCRIPTION
Fixed issue #8 "move dmps in a timestamped-sub-directory to avoid collisions"

The format of the subdirectory is "yyyy-MM-dd_HH-mm-ss_S".
Includes fix of bug which caused the dump download to fail if dump directory setting is not the default.
